### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 4.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 3.0 (2025-03-13)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  CHANGES
 =========
 
-3.1 (unreleased)
+4.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -44,9 +43,6 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     license='ZPL-2.1',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['z3c', 'z3c.recipe'],
     install_requires=[
         'setuptools',
         'zc.buildout >= 2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(path):
 
 setup(
     name='z3c.recipe.compattest',
-    version='3.1.dev0',
+    version='4.0.dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',
     description='Buildout recipe to create testrunners for testing '

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/src/z3c/recipe/__init__.py
+++ b/src/z3c/recipe/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
