### PR TITLE
Fix package lookup to use buildout working set instead of importlib.metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 4.2 (unreleased)
 ================
 
-- Nothing changed yet.
+- Revert replacement of ``pkg_resources`` with ``importlib.metadata`` in
+  ``recipe.py`` as ``importlib.metadata.distribution()`` cannot find packages
+  managed by buildout.
 
 
 4.1 (2026-04-17)

--- a/src/z3c/recipe/compattest/recipe.py
+++ b/src/z3c/recipe/compattest/recipe.py
@@ -1,6 +1,7 @@
-import importlib.metadata
 import os
 import re
+
+import pkg_resources
 
 import zc.buildout.easy_install
 import zc.recipe.egg
@@ -52,16 +53,14 @@ class Recipe:
     def _install_testrunners(self, wanted_packages):
         installed = []
         for package_name in wanted_packages:
-            dist = importlib.metadata.distribution(package_name)
+            ws = self._working_set(package_name)
+            package = ws.find(pkg_resources.Requirement.parse(package_name))
             # Installing arbitrary extras here leads to problems in
             # reproducibility.
             # In particular, setuptools[tests] causes a huge dependency tree
             # to be brought in.
             extras = '[{}]'.format(
-                ','.join(
-                    ex for ex in
-                    (dist.metadata.get_all('Provides-Extra') or [])
-                    if ex in ['test']))
+                ','.join(ex for ex in package.extras if ex in ['test']))
             if package_name == 'zc.buildout':
                 # Installing the test dependencies for zc.buildout is also a
                 # problem, they don't all provide test extras


### PR DESCRIPTION
This problem occurred while testing zopetoolkit with the new version of z3c.recipe.compattest (4.1).

`importlib.metadata.distribution()` only finds packages installed in `sys.path`, not eggs managed by buildout. This causes a `PackageNotFoundError` when the recipe tries to resolve packages (e.g. `zope.testing`) that buildout has resolved but not yet installed into the environment.

This PR reverts to using the buildout working set and `pkg_resources` to find package distributions and their extras, which correctly resolves eggs through buildout's egg resolution mechanism.